### PR TITLE
Use <video> tag instead of <iframe>

### DIFF
--- a/mkdocs_video/plugin.py
+++ b/mkdocs_video/plugin.py
@@ -59,12 +59,12 @@ class Plugin(mkdocs.plugins.BasePlugin):
             ["{}: {}".format(str(atr), str(style[atr])) for atr in style]
         )
 
-        return "<iframe "\
+        return "<video "\
+            "controls "\
+            "playsinline "\
             "src=\"{}\" "\
             "style=\"{}\" "\
-            "frameborder=\"0\" "\
-            "allowfullscreen>"\
-            "</iframe>".format(src, style)
+            "</video>".format(src, style)
 
 
     def find_marked_tags(self, content):


### PR DESCRIPTION
all modern browsers support <video>.
<iframe> is outdated and makes videos auto-starting in some browsers, which is particularly inconvenient in documentation contexts