### PR TITLE
Enables responsiveness

### DIFF
--- a/mkdocs_video/plugin.py
+++ b/mkdocs_video/plugin.py
@@ -59,12 +59,14 @@ class Plugin(mkdocs.plugins.BasePlugin):
             ["{}: {}".format(str(atr), str(style[atr])) for atr in style]
         )
 
-        return "<iframe "\
+        return "<div class=\"video-container\">"\
+            "<iframe "\
             "src=\"{}\" "\
             "style=\"{}\" "\
             "frameborder=\"0\" "\
             "allowfullscreen>"\
-            "</iframe>".format(src, style)
+            "</iframe>"\
+            "</div>".format(src, style)
 
 
     def find_marked_tags(self, content):


### PR DESCRIPTION
Wraps the iframe in a div with the class `video-container` to enable CSS styling.

In the `mkdocs.yml` I put:

```yml
extra_css:
  - css/extra.css
plugins:
  - mkdocs-video:
      css_style:
        position: "absolute"
        width: "100%"
        height: "100%"
```

And in the `extra.css`:

```css
.video-container {
  position: relative;
  padding-bottom: 56.25%;
  padding-top: 30px;
  height: 0;
  overflow: hidden;
}

.video-container iframe, .video-container object, .video-container embed { position: absolute;
  top: 0;
  left: 0;
  width: 100%;
  height: 100%;
}
```

Reference: https://avexdesigns.com/blog/responsive-youtube-embed