### PR TITLE
Handle emoji / unicode

### DIFF
--- a/mkdocs_video/plugin.py
+++ b/mkdocs_video/plugin.py
@@ -25,7 +25,7 @@ class Plugin(mkdocs.plugins.BasePlugin):
 
 
     def on_page_content(self, html, page, config, files):
-        content = lxml.html.fromstring(html)
+        content = lxml.html.fromstring(html.encode("unicode-escape"))
         tags = content.xpath(f'//img[@alt="{self.config["mark"]}" and @src]')
         for tag in tags:
             if not tag.attrib.get("src"):


### PR DESCRIPTION
Similar to https://github.com/squidfunk/mkdocs-material/issues/5126, certain emoji lead to the error `lxml.etree.ParserError: Document is empty`. This escapes them so to avoid that error.